### PR TITLE
change form classes to new rim prefix

### DIFF
--- a/assets/stylesheets/sass/_menu.scss
+++ b/assets/stylesheets/sass/_menu.scss
@@ -213,7 +213,7 @@
   padding: map-get($spacers, 4);
   width: 25rem;
 
-  .crm-form__field {
+  .rim-form__field {
     margin-bottom: map-get($spacers, 3);
   }
 }

--- a/pages/crm-contracts.html
+++ b/pages/crm-contracts.html
@@ -100,23 +100,23 @@
       <div class="site-menu__item has-dropdown">
         <i class="fas fa-ticket-alt rotate-45"></i>
         <div class="dropdown-menu agent-contact">
-          <form action="" class="crm-form crm-form--stacked crm-form--light">
-            <label for="agent-name" class="crm-form__field">Name
+          <form action="" class="rim-form rim-form--stacked rim-form--light">
+            <label for="agent-name" class="rim-form__field">Name
               <input id="agent-name" type="text" placeholder="First and Last Name">
             </label>
-            <label for="agent-email" class="crm-form__field">Email
+            <label for="agent-email" class="rim-form__field">Email
               <input id="agent-email" type="email" placeholder="geg.gudis@bgainsurances.net">
             </label>
-            <label for="agent-phone" class="crm-form__field">Phone
+            <label for="agent-phone" class="rim-form__field">Phone
               <input id="agent-phone" type="tel" placeholder="(610) 828-3553x302">
             </label>
-            <label for="subject" class="crm-form__field">Subject
+            <label for="subject" class="rim-form__field">Subject
               <input id="subject" type="text" placeholder="">
             </label>
-            <label for="message" class="crm-form__field">Message
+            <label for="message" class="rim-form__field">Message
               <textarea id="message" name="message" rows="10" ></textarea>
             </label>
-            <div class="crm-form__field crm-form__button-group">
+            <div class="rim-form__field rim-form__button-group">
               <button class="button button--post button--lg">Submit</button>
             </div>
           </form>

--- a/pages/crm-spike-grid-flex.html
+++ b/pages/crm-spike-grid-flex.html
@@ -100,23 +100,23 @@
       <div class="site-menu__item has-dropdown">
         <i class="fas fa-ticket-alt rotate-45"></i>
         <div class="dropdown-menu agent-contact">
-          <form action="" class="crm-form crm-form--stacked crm-form--light">
-            <label for="agent-name" class="crm-form__field">Name
+          <form action="" class="rim-form rim-form--stacked rim-form--light">
+            <label for="agent-name" class="rim-form__field">Name
               <input id="agent-name" type="text" placeholder="First and Last Name">
             </label>
-            <label for="agent-email" class="crm-form__field">Email
+            <label for="agent-email" class="rim-form__field">Email
               <input id="agent-email" type="email" placeholder="geg.gudis@bgainsurances.net">
             </label>
-            <label for="agent-phone" class="crm-form__field">Phone
+            <label for="agent-phone" class="rim-form__field">Phone
               <input id="agent-phone" type="tel" placeholder="(610) 828-3553x302">
             </label>
-            <label for="subject" class="crm-form__field">Subject
+            <label for="subject" class="rim-form__field">Subject
               <input id="subject" type="text" placeholder="">
             </label>
-            <label for="message" class="crm-form__field">Message
+            <label for="message" class="rim-form__field">Message
               <textarea id="message" name="message" rows="10" ></textarea>
             </label>
-            <div class="crm-form__field crm-form__button-group">
+            <div class="rim-form__field rim-form__button-group">
               <button class="button button--post button--lg">Submit</button>
             </div>
           </form>


### PR DESCRIPTION
I changed `crm-form` to `rim-form` last week but missed some instances. Specifically the form in the screenshot attached...
<img width="454" alt="Screen Shot 2019-05-14 at 1 22 06 PM" src="https://user-images.githubusercontent.com/5313708/57718458-514aeb80-764b-11e9-9ecc-39fbf0824167.png">
