### PR TITLE
styleguide button edit for accessibility

### DIFF
--- a/assets/stylesheets/sass/_buttons.scss
+++ b/assets/stylesheets/sass/_buttons.scss
@@ -71,6 +71,22 @@
 //
 // Styleguide Components.Button.Group
 
+// Accessibility
+//
+// For our links that should look like buttons, and contain an icon, we need to add specific 
+// aria roles for accessibility. 
+// These are links that look like buttons but do not have the same html.
+//
+//
+// Markup:
+// <a class="button button--secondary" role="button" aria-label="Download">
+//  <i class="fas fa-download" focusable="false" aria-hidden="hidden"></i>
+// </a>
+//
+// Weight: 6
+//
+// Styleguide Components.Button.Accessibility
+
 
 .button {
 


### PR DESCRIPTION
Added an example for a link that looks like a button but the html is _not_ a `<button>`.