### PR TITLE
Add styles for pill filter

### DIFF
--- a/assets/stylesheets/sass/_forms.scss
+++ b/assets/stylesheets/sass/_forms.scss
@@ -496,3 +496,46 @@ input[type="radio"] {
     }
   }
 }
+
+input[type="checkbox"].pill-filter, input[type="radio"].pill-filter {
+
+  + label {
+    background-color: map-get($greyscale, 'white');
+    border-radius: map-get($radius, 'button');
+    color: map-get($platform-colors, 'link');
+    border: 1px solid map-get($platform-colors, 'link');
+    height: auto;
+    justify-content: center;
+    margin: .25rem;
+    padding: map-get($spacers, 2) 1.5rem;
+    transition: $transitions;
+    i {
+      font-size: map-get($font-percentage, 'xs');
+    }
+
+    &:before {
+      display: none;
+    }
+
+    &:after {
+      color: map-get($greyscale, 'white');
+      left: .5rem;
+      opacity: 0;
+      top: 50%;
+      transform: translateY(-50%);
+      transition: visibility $duration ease, opacity $duration ease;
+      visibility: hidden;
+    }
+  }
+
+  &:checked + label {
+    background-color: map-get($platform-colors, 'link' );
+    font-weight: 400;
+    color: map-get($greyscale, 'white');
+
+    &:after {
+      opacity: 1;
+      visibility: visible;
+    }
+  }
+}

--- a/assets/stylesheets/sass/_info-box.scss
+++ b/assets/stylesheets/sass/_info-box.scss
@@ -5,7 +5,6 @@
     background-color: map-get($greyscale, 'white');
     border: 1px solid lighten(map-get($greyscale, 'light'), $hue-threshold * 2);
     box-shadow: 0 2px 4px 2px map-get($greyscale, 'lighter' );
-    display: none;
     margin-top: $spacer;
     min-width: 20rem;
     padding: map-get($spacers, 5) map-get($spacers, 4);

--- a/pages/crm-spike-grid-flex.html
+++ b/pages/crm-spike-grid-flex.html
@@ -251,7 +251,7 @@
           <a class="button button--secondary" role="button" aria-label="Toggle">
             <i class="fas fa-sliders-h" focusable="false" aria-hidden="hidden"></i>
           </a>
-          <div class="rim-info-box__content">
+          <div class="rim-info-box__content hidden">
             <button class="button rim-info-box__close">
               Close <i class="fas fa-times" focusable="false" aria-hidden="hidden"></i>
             </button>


### PR DESCRIPTION
Adds styles for `.pill-filter`, available to be used on `checkbox` and `radio`. Note that if you are using a `radio` input, you must manually supply the `<i class="fas fa-check"></i>` in the label and toggle it on and off based on whether it is selected.

There is a fair bit of duplication here from the `filter-group > filter-group__filter` styles, but I figured this would be easier for you guys if I stripped it out and made it standalone.

Example usage, inside of a `<div class="flexcol">`:
```
  <fieldset class="rim-form__field rim-form__field--full">
      <template v-for="(item, index) in availableItems">
        <input :id="item.key || item" :name="item.key || item" type="radio" :key="`input${index}`" class="pill-filter" :value="item.key || item" v-model="selectedItem" @change="updateSelectedItem">
        <label :key="`label${index}`" :for="item.key || item">
          <i v-if="selectedItem == item || selectedItem == item.key" class="fas fa-check"></i> {{ item.shortName || item }}
        </label>
      </template>
  </fieldset>
```
![pill-radio-filter](https://user-images.githubusercontent.com/24712731/59788719-90431100-9289-11e9-8866-4c6e00734341.PNG)

Also removes `display: none;` from the `rim-info-box__content` and adds the `hidden` class to the example usage of it so that it won't be obstructing the view.