### PR TITLE
Add type=number to basic input styles

### DIFF
--- a/assets/stylesheets/sass/_forms.scss
+++ b/assets/stylesheets/sass/_forms.scss
@@ -217,6 +217,7 @@ input[type="radio"] {
     input[type="textarea"],
     input[type="tel"],
     input[type="password"],
+    input[type="number"]
     textarea,
     select {
       border-bottom-color: map-get($greyscale, 'white' );


### PR DESCRIPTION
`type="number"` was missing from the styled inputs so I added it.