### PR TITLE
Prevent body scrolling when .modal-open is added

### DIFF
--- a/src/assets/js/src/modal.js
+++ b/src/assets/js/src/modal.js
@@ -8,6 +8,7 @@ if(closeModal) {
       let modal = document.getElementById(el.dataset.modal);
       modal.classList.toggle('rim-modal--closed');
       modalOverlay.classList.toggle('rim-modal--closed');
+      document.body.classList.remove('modal-open');
     });
   });
 }
@@ -18,6 +19,9 @@ if(openModal) {
       let modal = document.getElementById(el.dataset.modal);
       modal.classList.toggle('rim-modal--closed');
       modalOverlay.classList.toggle('rim-modal--closed');
+      if(el.dataset.noScroll) { 
+        document.body.classList.add('modal-open');
+      }
     });
   });
 }

--- a/src/assets/stylesheets/sass/_modal.scss
+++ b/src/assets/stylesheets/sass/_modal.scss
@@ -8,6 +8,8 @@
 //
 // The default size of the modal is `medium`, you can use `rim-modal--small`, `rim-modal--large`, or `rim-modal--full` for different sized modals.
 //
+// You may run into issues where the background scrolls while your modal is open. To prevent this behavior, add the `.modal-open` class to your body element when a modal is open. See demo below for example and note how adding the `.modal-open` class to the body on open makes the background scroll bar go away.
+//
 // Markup:
 // <div class="rim-modal--overlay rim-modal--closed"></div>
 // <div id="default-modal" class="rim-modal rim-modal--closed ">
@@ -60,7 +62,7 @@
 //     </div>
 //   </div>
 // </div>
-// <button class="button button--post button--lg rim-modal__open" data-modal="default-modal">Trigger Modal</button> <button class="button button--post button--lg rim-modal__open" data-modal="small-modal">Small Modal</button> <button class="button button--post button--lg rim-modal__open" data-modal="large-modal">Large Modal</button> <button class="button button--post button--lg rim-modal__open" data-modal="full-modal">Full Screen Modal</button>
+// <button class="button button--post button--lg rim-modal__open" data-modal="default-modal">Trigger Modal</button> <button class="button button--post button--lg rim-modal__open" data-modal="small-modal">Small Modal</button> <button class="button button--post button--lg rim-modal__open" data-modal="large-modal">Large Modal</button> <button class="button button--post button--lg rim-modal__open" data-modal="full-modal">Full Screen Modal</button> <button class="button button--post button--lg rim-modal__open" data-modal="full-modal" data-no-scroll="true">Full Screen Modal (No background scroll)</button>
 //
 // Styleguide Components.modal
 
@@ -161,4 +163,10 @@
       width: 100%;
     }
   }
+}
+
+body.modal-open {
+  // REF: https://css-tricks.com/prevent-page-scrolling-when-a-modal-is-open/#article-header-id-0
+  height: 100vh;
+  overflow-y: hidden;
 }


### PR DESCRIPTION
Adding `modal-open` class to the body element prevents scrolling the body. Class should be added to body when a modal is open and we run into an issue where the background scrolls. See https://css-tricks.com/prevent-page-scrolling-when-a-modal-is-open/ for more info.