### PR TITLE
remove placeholder on date inputs

### DIFF
--- a/demo-pages/crm-spike-grid-flex.html
+++ b/demo-pages/crm-spike-grid-flex.html
@@ -332,11 +332,11 @@
             </button>
             <form action="" class="block-container block-mb-4 rim-form">
               <label for="dob" class="block rim-form__field has-icon">Age or DOB
-                <input id="dob" type="date" placeholder="DD/MM/YYYY">
+                <input id="dob" type="date">
                 <i class="fas fa-calendar-alt text-skyblue background-white"></i>
               </label>
               <label for="dob" class="block rim-form__field has-icon">Age or DOB
-                <input id="dob" type="date" placeholder="DD/MM/YYYY">
+                <input id="dob" type="date">
                 <i class="fas fa-calendar-alt text-skyblue background-white"></i>
               </label>
               <fieldset class="block rim-form__field">
@@ -1135,7 +1135,7 @@
         </div>
         <div class="block">
           <label for="dob" class="rim-form__field">Age or DOB
-            <input id="dob" type="date" placeholder="DD/MM/YYYY">
+            <input id="dob" type="date">
           </label>
         </div>
         <div class="block">
@@ -1196,7 +1196,7 @@
         </div>
         <div class="block">
           <label for="dob" class="rim-form__field has-icon">Application Date
-            <input id="dob" type="date" placeholder="DD/MM/YYYY">
+            <input id="dob" type="date">
             <i class="fas fa-calendar-alt text-skyblue background-white"></i>
           </label>
         </div>

--- a/src/assets/stylesheets/sass/_forms.scss
+++ b/src/assets/stylesheets/sass/_forms.scss
@@ -15,7 +15,7 @@
 //   </div>
 //   <div class="block">
 //     <label for="dob" class="rim-form__field">Age or DOB
-//       <input id="dob" type="date" placeholder="DD/MM/YYYY">
+//       <input id="dob" type="date">
 //     </label>
 //   </div>
 //   <div class="block">
@@ -76,7 +76,7 @@
 //   </div>
 //   <div class="block">
 //     <label for="dob" class="rim-form__field has-icon">Application Date
-//       <input id="dob" type="date" placeholder="DD/MM/YYYY">
+//       <input id="dob" type="date">
 //       <i class="fas fa-calendar-alt text-skyblue background-white"></i>
 //     </label>
 //   </div>
@@ -156,7 +156,7 @@
 //   </div>
 //   <div class="block">
 //     <label for="dob" class="rim-form__field">Age or DOB
-//       <input id="dob" type="date" placeholder="DD/MM/YYYY">
+//       <input id="dob" type="date">
 //     </label>
 //   </div>
 //   <div class="block">


### PR DESCRIPTION
To avoid confusion, the `placeholder` attribute has been removed from `input type="date"`.