### PR TITLE
remove specific font size from close icon in pill__close

### DIFF
--- a/src/assets/stylesheets/sass/_pills.scss
+++ b/src/assets/stylesheets/sass/_pills.scss
@@ -153,9 +153,6 @@
     position: absolute;
     right: -.2rem;
     top: -.6rem;
-    i {
-      font-size: 1.2rem;
-    }
     :hover {
       cursor: pointer;
     }


### PR DESCRIPTION
**Before**
<img width="106" alt="Screen Shot 2019-11-25 at 1 11 55 PM" src="https://user-images.githubusercontent.com/5313708/69566743-c9dd1e00-0f85-11ea-8246-cb085cb0c09d.png">



**After**
<img width="103" alt="Screen Shot 2019-11-25 at 1 12 40 PM" src="https://user-images.githubusercontent.com/5313708/69566758-cf3a6880-0f85-11ea-930e-54b1a0561b81.png">
