### PR TITLE
Skip visual tests in deploy build (Merge PR)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,9 +21,6 @@ after_build:
 cache:
   - node_modules -> package.json, package-lock.json
 
-test_script:
-  - npm run browser-visual-tests
-
 artifacts:
   - path: ./styleguide.zip
     name: Styleguide

--- a/build.cmd
+++ b/build.cmd
@@ -1,6 +1,7 @@
 @echo Off
 pushd %~dp0
 setlocal
+set pull_request_number=%APPVEYOR_PULL_REQUEST_NUMBER%
 
 :Build
 call npm install
@@ -8,6 +9,12 @@ if %ERRORLEVEL% neq 0 goto BuildFail
 
 call npm run build
 if %ERRORLEVEL% neq 0 goto BuildFail
+
+if %pull_request_number% gtr 0 (
+  echo "In pull request. Not Deploying."
+  CALL npm run browser-visual-tests
+  if %ERRORLEVEL% neq 0 goto BuildFail
+)
 
 goto BuildSuccess
 


### PR DESCRIPTION
We were previously running the visual tests for merge PRs as well as new PRs. This changes that so we only run it for new PRs.