### PR TITLE
Only run build for stable version of Node

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,6 @@ environment:
   matrix:
     - nodejs_version: STABLE
       configuration: publish
-    - nodejs_version: LTS
 
 install:
   - ps: Install-Product node $env:nodejs_version


### PR DESCRIPTION
We don't need to run in multiple node versions