### PR TITLE
remove redundant mobile classes

### DIFF
--- a/demo-pages/blocks.html
+++ b/demo-pages/blocks.html
@@ -70,7 +70,7 @@
             <div class="w-100 h-100 background-skyblue"></div>
           </div>
           <div class="block block-8">
-            <div class="block-container mobile-up-2 lg-tablet-up-6 blocks px-2 py-2">
+            <div class="block-container mobile-up-2 lg-tablet-up-6 blocks p-2">
               <div class="block" style="height: 10rem;">
                 <div class="w-100 h-100 background-skyblue"></div>
               </div>

--- a/src/assets/stylesheets/sass/_blocks.scss
+++ b/src/assets/stylesheets/sass/_blocks.scss
@@ -396,10 +396,21 @@
           }
 
           &.blocks {
+            &[class*="p-"],
             &[class*="px"] {
               > .block {
                 @if $index < length(config.$breakpoints) {
                   @media screen and (min-width : ($name)) and (max-width: map.get(config.$breakpoints, mixins.nextKey($breakpoint) )  - 1 ) {
+                    &:nth-child(#{$val}n+1) {
+                      padding-left: 0;
+                    }
+  
+                    &:nth-child(#{$val}n+#{$val}) {
+                      padding-right: 0;
+                    }
+                  }
+                } @else {
+                  @include mixins.breakpoint(#{$name}, min) {
                     &:nth-child(#{$val}n+1) {
                       padding-left: 0;
                     }


### PR DESCRIPTION
No visual changes. This PR was to remove unnecessary responsive modifiers for our black layout. 