### PR TITLE
fix-no-hover background, remove pointer from th

### DIFF
--- a/src/assets/stylesheets/sass/_tables.scss
+++ b/src/assets/stylesheets/sass/_tables.scss
@@ -192,10 +192,6 @@
       padding: 1rem;
     }
 
-    th {
-      cursor: pointer;
-    }
-
     td {
       border-bottom: 1px solid color.adjust(map.get(variables.$greyscale, 'light'), $lightness: math.percentage(config.$hue-threshold * 2));
     }
@@ -246,7 +242,11 @@
   }
   &--no-hover {
     tr {
-      background-color: transparent !important;
+      @include mixins.breakpoint(tablet, min) {
+        &:hover {
+          background-color: initial;
+        }
+      }
     }
   }
   &--bordered {


### PR DESCRIPTION
**Issue:** https://github.com/ritterim/platform-ui/issues/334
**Issue:** https://github.com/ritterim/platform-ui/issues/301

With the `no-hover` modifier the background color was transparent. Changed it to `initial`.
I removed the `cursor: pointer` on the `th`s within the tables. 