### PR TITLE
bring back active background, add new link class to site menus

### DIFF
--- a/demo-pages/accessibility.html
+++ b/demo-pages/accessibility.html
@@ -2717,25 +2717,31 @@ does not render a different font due to the icon having the font-awesome font st
                       <header class="site-header pos-rel background-base">
         <nav class="site-menu">
           <div class="site-menu__item has-dropdown">
-            <span class="card__header-icon pill--circle-medium background-pink text-white mr-2">
-              <i class="pi-rimdev text-base"></i>
-            </span>
-            <div class="font-lg">
-              Menu Header with avatar
-            </div>
-        </div>
-        <div class="site-menu__item">
-          menu item
-        </div>
-        <div class="site-menu__item has-dropdown">
-          dropdown item
-          <div class="dropdown-menu pin-right hide-mobile-up">
-            <div class="dropdown-menu__item">
-              dropdown
-            </div>
+            <a href="#" class="site-menu__link">
+              <span class="card__header-icon pill--circle-medium background-pink text-white mr-2">
+                <i class="pi-rimdev text-base"></i>
+              </span>
+              <div class="font-lg">
+                Menu Header with avatar
+              </div>
+            </a>
           </div>
-        </div>
-      </nav>
+          <div class="site-menu__item">
+            <a href="#" class="site-menu__link">
+              menu item
+            </a>
+          </div>
+          <div class="site-menu__item has-dropdown">
+            <a href="#" class="site-menu__link">
+              dropdown item
+              <div class="dropdown-menu pin-right hide-mobile-up">
+                <div class="dropdown-menu__item">
+                  dropdown
+                </div>
+              </div>
+            </a>
+          </div>
+        </nav>
       </header>
                       <div class="pui-style-modifier__example-footer"></div>
                     </div>

--- a/demo-pages/accordions.html
+++ b/demo-pages/accordions.html
@@ -13,14 +13,16 @@
 <body class="flex flex--column">
   <header class="site-header site-header--fixed">
     <nav class="site-menu primary inverted">
-        <a href="/demo-pages/crm-example.html" class="site-menu__item">
+        <div class="site-menu__item">
+          <a href="/demo-pages/crm-example.html" class="site-menu__link">
             <span class="card__header-icon pill--circle-medium background-purple text-white mr-2">
                 D
             </span>
             <span class="text--size-lg">
                 Hello Dev
             </span>
-        </a>
+          </a>
+        </div>
         <div class="site-menu__item search">
             <form role="search" aria-label="CRM" _lpchecked="1" class="w-100">
                 <div class="flex flex--align-center">
@@ -30,60 +32,72 @@
                 </div>
             </form>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
+        <div class="site-menu__item has-dropdown">
+          <a href="#" class="site-menu__link">
             Organizations <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
-            <div class="dropdown-menu pin-right">
-                <a href="#" class="dropdown-menu__item">
-                    dropdown
-                </a>
-            </div>
+          </a>
+          <div class="dropdown-menu pin-right">
+              <a href="#" class="dropdown-menu__item">
+                  dropdown
+              </a>
+          </div>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
+        <div class="site-menu__item has-dropdown">
+          <a href="#" class="site-menu__link">
             People <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
-            <div class="dropdown-menu pin-right">
-                <a href="#" class="dropdown-menu__item">
-                    dropdown
-                </a>
-            </div>
+          </a>   
+          <div class="dropdown-menu pin-right">
+              <a href="#" class="dropdown-menu__item">
+                  dropdown
+              </a>
+          </div>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
+        <div class="site-menu__item has-dropdown">
+          <a href="#" class="site-menu__link">
             Flow <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
-            <div class="dropdown-menu pin-right">
-                <a href="#" class="dropdown-menu__item">
-                    dropdown
-                </a>
-            </div>
+          </a>  
+          <div class="dropdown-menu pin-right">
+              <a href="#" class="dropdown-menu__item">
+                  dropdown
+              </a>
+          </div>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
+        <div class="site-menu__item has-dropdown">
+          <a href="#" class="site-menu__link">
             <span class="sr-only">RIMDev</span>
             <span class="pill--circle-medium background-white text-navy">
                 <i class="pi-rimdev text--size-xl" aria-hidden="true"></i>
             </span>
             <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
-            <div class="dropdown-menu pin-right">
-                <a href="#" class="dropdown-menu__item">
-                    dropdown
-                </a>
-            </div>
+          </a>  
+          <div class="dropdown-menu pin-right">
+              <a href="#" class="dropdown-menu__item">
+                  dropdown
+              </a>
+          </div>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            Recent <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
-            <div class="dropdown-menu pin-right">
-                <a href="#" class="dropdown-menu__item">
-                    dropdown
-                </a>
-            </div>
+        <div class="site-menu__item has-dropdown">
+          <a href="#" class="site-menu__link">
+            Recent <i class="ml-1 pi-angle-down" aria-hidden="true"></i>            
+          </a>
+          <div class="dropdown-menu pin-right">
+              <a href="#" class="dropdown-menu__item">
+                  dropdown
+              </a>
+          </div>
         </div>
     </nav>
     <nav class="site-menu flex--justify-between">
         <div class="site-menu__item has-dropdown">
-          <span class="card__header-icon pill--circle-medium background-salmon text-white mr-2">
-              GG
-          </span>
-          <div class="text--size-lg">
-            Greg Gudis
-          </div>
-          <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+          <a href="#" class="site-menu__link">
+            <span class="card__header-icon pill--circle-medium background-salmon text-white mr-2">
+                GG
+            </span>
+            <div class="text--size-lg">
+              Greg Gudis
+            </div>
+            <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+          </a>
           <div class="dropdown-menu pin-right">
             <a href="#" class="dropdown-menu__item background-white">
               <div class="pill background-olive">
@@ -93,41 +107,59 @@
           </div>
         </div>
         <div class="flex">
-            <div class="site-menu__item">
-                Contracts
-            </div>
-            <div class="site-menu__item active">
-                Submissions
-            </div>
-            <div class="site-menu__item">
-                Hierarchy
-            </div>
-            <div class="site-menu__item">
-                Memberships
-            </div>
-            <div class="site-menu__item">
-                Licenses
-            </div>
-            <div class="site-menu__item">
-                Reports
-            </div>
-            <div class="site-menu__item">
-                <i class="pi-phone"></i>
-            </div>
-            <div class="site-menu__item">
-                <i class="pi-file-cabinet"></i>
-                <div class="ml-1 pill pill--circle text-navy">
-                  33
-                </div>
-            </div>
-            <div class="site-menu__item">
-                <i class="pi-gavel"></i>
-                <div class="pill pill--split text-white background-navy">
-                  <div class="pill__content background-salmon">5</div>
-                  <div class="pill__content background-olive">2</div>
-                  <div class="pill__content background-skyblue">13</div>
-                </div>
-            </div>
+          <div class="site-menu__item">
+            <a href="#" class="site-menu__link">
+              Contracts
+            </a>
+          </div>
+          <div class="site-menu__item active">
+            <a href="#" class="site-menu__link">
+              Submissions
+            </a>
+          </div>
+          <div class="site-menu__item">
+            <a href="#" class="site-menu__link">
+              Hierarchy
+            </a>
+          </div>
+          <div class="site-menu__item">
+            <a href="#" class="site-menu__link">
+              Memberships
+            </a>
+          </div>
+          <div class="site-menu__item">
+            <a href="#" class="site-menu__link">
+              Licenses
+            </a>
+          </div>
+          <div class="site-menu__item">
+            <a href="#" class="site-menu__link">
+              Reports
+            </a>
+          </div>
+          <div class="site-menu__item">
+            <a href="#" class="site-menu__link">
+              <i class="pi-phone"></i>
+            </a>
+          </div>
+          <div class="site-menu__item">
+            <a href="#" class="site-menu__link">
+              <i class="pi-file-cabinet"></i>
+              <div class="ml-1 pill pill--circle text-navy">
+                33
+              </div>
+            </a>
+          </div>
+          <div class="site-menu__item">
+            <a href="#" class="site-menu__link">
+              <i class="pi-gavel"></i>
+              <div class="pill pill--split text-white background-navy">
+                <div class="pill__content background-salmon">5</div>
+                <div class="pill__content background-olive">2</div>
+                <div class="pill__content background-skyblue">13</div>
+              </div>
+            </a>
+          </div>
         </div>
     </nav>
   </header>

--- a/demo-pages/blocks.html
+++ b/demo-pages/blocks.html
@@ -44,22 +44,28 @@
     <header class="site-header site-header--fixed">
       <nav class="site-menu flex--justify-between">
         <div class="site-menu__item">
-          <span
-            class="card__header-icon pill--circle-medium background-salmon text-white mr-2"
-          >
-            <i class="pi-building text-white"></i>
-          </span>
-          <div class="text--size-lg">
-            Humana
-          </div>
-          <span class="pill text-white background-olive ml-3">Active</span>
+          <a href="#" class="site-menu__link">
+            <span
+              class="card__header-icon pill--circle-medium background-salmon text-white mr-2"
+            >
+              <i class="pi-building text-white"></i>
+            </span>
+            <div class="text--size-lg">
+              Humana
+            </div>
+            <span class="pill text-white background-olive ml-3">Active</span>
+          </a>
         </div>
         <div class="flex">
           <div class="site-menu__item active">
-            Contracts
+            <a href="#" class="site-menu__link">
+              Contracts
+            </a>
           </div>
           <div class="site-menu__item">
-            Membership
+            <a href="#" class="site-menu__link">
+              Membership
+            </a>
           </div>
         </div>
       </nav>

--- a/demo-pages/crm-example.html
+++ b/demo-pages/crm-example.html
@@ -21,14 +21,16 @@
 <body class="flex flex--column">
   <header class="site-header site-header--fixed">
     <nav class="site-menu primary inverted">
-        <a href="/demo-pages/crm-example.html" class="site-menu__item">
-            <span class="card__header-icon pill--circle-medium background-purple text-white mr-2">
-                GG
-            </span>
-            <span class="text--size-lg">
-                Hello Greg
-            </span>
-        </a>
+        <div class="site-menu__item">
+            <a href="/demo-pages/crm-example.html" class="site-menu__link">
+                <span class="card__header-icon pill--circle-medium background-purple text-white mr-2">
+                    GG
+                </span>
+                <span class="text--size-lg">
+                    Hello Greg
+                </span>
+            </a>
+        </div>
         <div class="site-menu__item search">
             <form role="search" aria-label="CRM" _lpchecked="1" class="w-100">
                 <div class="flex flex--align-center">
@@ -38,44 +40,54 @@
                 </div>
             </form>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            Organizations <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+        <div class="site-menu__item has-dropdown">
+            <a href="#" class="site-menu__link">
+                Organizations <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+            </a>
             <div class="dropdown-menu pin-right">
                 <a href="#" class="dropdown-menu__item">
                     dropdown
                 </a>
             </div>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            People <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+        <div class="site-menu__item has-dropdown">
+            <a href="#" class="site-menu__link">
+                People <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+            </a>
             <div class="dropdown-menu pin-right">
                 <a href="#" class="dropdown-menu__item">
                     dropdown
                 </a>
             </div>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            Flow <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+        <div class="site-menu__item has-dropdown">
+            <a href="#" class="site-menu__link">
+                Flow <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+            </a>
             <div class="dropdown-menu pin-right">
                 <a href="#" class="dropdown-menu__item">
                     dropdown
                 </a>
             </div>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            <span class="sr-only">RIMDev</span>
-            <span class="card__header-icon pill--circle-medium background-white text-navy">
-                <i class="pi-rimdev" aria-hidden="true"></i>
-            </span> 
-            <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+        <div class="site-menu__item has-dropdown">
+            <a href="#" class="site-menu__link">
+                <span class="sr-only">RIMDev</span>
+                <span class="card__header-icon pill--circle-medium background-white text-navy">
+                    <i class="pi-rimdev" aria-hidden="true"></i>
+                </span> 
+                <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+            </a>
             <div class="dropdown-menu pin-right">
                 <a href="#" class="dropdown-menu__item">
                     dropdown
                 </a>
             </div>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            Recent <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+        <div class="site-menu__item has-dropdown">
+            <a href="#" class="site-menu__link">
+                Recent <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+            </a>
             <div class="dropdown-menu pin-right">
                 <a href="#" class="dropdown-menu__item">
                     dropdown
@@ -85,20 +97,26 @@
     </nav>
     <nav class="site-menu flex--justify-between">
         <div class="site-menu__item">
-            <span class="card__header-icon pill--circle-medium background-salmon text-white mr-2">
-                <i class="pi-building text-white"></i>
-            </span>
-            <div class="text--size-lg">
-                Humana
-            </div>
-            <span class="pill text-white background-olive ml-3">Active</span>
+            <a href="#" class="site-menu__link">
+                <span class="card__header-icon pill--circle-medium background-salmon text-white mr-2">
+                    <i class="pi-building text-white"></i>
+                </span>
+                <div class="text--size-lg">
+                    Humana
+                </div>
+                <span class="pill text-white background-olive ml-3">Active</span>
+            </a>            
         </div>
         <div class="flex">
             <div class="site-menu__item active">
-                Contracts
+                <a href="#" class="site-menu__link">
+                    Contracts
+                </a>                
             </div>
             <div class="site-menu__item">
-                Membership
+                <a href="#" class="site-menu__link">
+                    Membership
+                </a>                
             </div>
         </div>
     </nav>

--- a/demo-pages/submissions-modals.html
+++ b/demo-pages/submissions-modals.html
@@ -26,61 +26,73 @@
 <body class="flex flex--column">
   <header class="site-header site-header--fixed">
     <nav class="site-menu primary inverted">
-        <a href="/demo-pages/crm-example.html" class="site-menu__item">
-            <span class="card__header-icon pill--circle-medium background-purple text-white mr-2">
-                D
-            </span>
-            <span class="text--size-lg">
-                Hello Dev
-            </span>
-        </a>
+        <div class="site-menu__item">
+            <a href="/demo-pages/crm-example.html" class="site-menu__link">
+                <span class="card__header-icon pill--circle-medium background-purple text-white mr-2">
+                    GG
+                </span>
+                <span class="text--size-lg">
+                    Hello Greg
+                </span>
+            </a>
+        </div>
         <div class="site-menu__item search">
             <form role="search" aria-label="CRM" _lpchecked="1" class="w-100">
                 <div class="flex flex--align-center">
-                    <label for="search-input" class="sr-only">Search</label>
+                    <label for="search-input" class="sr-only">Search</label> 
                     <input type="text" id="search-input" placeholder="Type to search..." class="placeholder--light text-white">
                     <i aria-hidden="true" class="pi-search"></i>
                 </div>
             </form>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            Organizations <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+        <div class="site-menu__item has-dropdown">
+            <a href="#" class="site-menu__link">
+                Organizations <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+            </a>
             <div class="dropdown-menu pin-right">
                 <a href="#" class="dropdown-menu__item">
                     dropdown
                 </a>
             </div>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            People <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+        <div class="site-menu__item has-dropdown">
+            <a href="#" class="site-menu__link">
+                People <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+            </a>
             <div class="dropdown-menu pin-right">
                 <a href="#" class="dropdown-menu__item">
                     dropdown
                 </a>
             </div>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            Flow <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+        <div class="site-menu__item has-dropdown">
+            <a href="#" class="site-menu__link">
+                Flow <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+            </a>
             <div class="dropdown-menu pin-right">
                 <a href="#" class="dropdown-menu__item">
                     dropdown
                 </a>
             </div>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            <span class="sr-only">RIMDev</span>
-            <span class="pill--circle-medium background-white text-navy">
-                <i class="pi-rimdev text--size-xl" aria-hidden="true"></i>
-            </span>
-            <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+        <div class="site-menu__item has-dropdown">
+            <a href="#" class="site-menu__link">
+                <span class="sr-only">RIMDev</span>
+                <span class="card__header-icon pill--circle-medium background-white text-navy">
+                    <i class="pi-rimdev" aria-hidden="true"></i>
+                </span> 
+                <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+            </a>
             <div class="dropdown-menu pin-right">
                 <a href="#" class="dropdown-menu__item">
                     dropdown
                 </a>
             </div>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            Recent <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+        <div class="site-menu__item has-dropdown">
+            <a href="#" class="site-menu__link">
+                Recent <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+            </a>
             <div class="dropdown-menu pin-right">
                 <a href="#" class="dropdown-menu__item">
                     dropdown
@@ -90,13 +102,15 @@
     </nav>
     <nav class="site-menu flex--justify-between">
         <div class="site-menu__item has-dropdown">
-          <span class="card__header-icon pill--circle-medium background-salmon text-white mr-2">
-              GG
-          </span>
-          <div class="text--size-lg">
-            Greg Gudis
-          </div>
-          <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+          <a href="#" class="site-menu__link">
+            <span class="card__header-icon pill--circle-medium background-salmon text-white mr-2">
+                GG
+            </span>
+            <div class="text--size-lg">
+              Greg Gudis
+            </div>
+            <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+          </a>
           <div class="dropdown-menu pin-right">
             <a href="#" class="dropdown-menu__item background-white">
               <div class="pill background-olive">
@@ -107,39 +121,57 @@
         </div>
         <div class="flex">
             <div class="site-menu__item">
+              <a href="#" class="site-menu__link">
                 Contracts
+              </a>
             </div>
             <div class="site-menu__item active">
+              <a href="#" class="site-menu__link">
                 Submissions
+              </a>
             </div>
             <div class="site-menu__item">
+              <a href="#" class="site-menu__link">
                 Hierarchy
+              </a>
             </div>
             <div class="site-menu__item">
+              <a href="#" class="site-menu__link">
                 Memberships
+              </a>
             </div>
             <div class="site-menu__item">
+              <a href="#" class="site-menu__link">
                 Licenses
+              </a>
             </div>
             <div class="site-menu__item">
+              <a href="#" class="site-menu__link">
                 Reports
+              </a>
             </div>
             <div class="site-menu__item pui-drawer__open" data-drawer="touches">
+              <a href="#" class="site-menu__link">
                 <i class="pi-phone"></i>
+              </a>
             </div>
             <div class="site-menu__item">
+              <a href="#" class="site-menu__link">
                 <i class="pi-file-cabinet"></i>
                 <div class="ml-1 pill pill--circle text-navy">
                   33
                 </div>
+              </a>
             </div>
             <div class="site-menu__item">
+              <a href="#" class="site-menu__link">
                 <i class="pi-gavel"></i>
                 <div class="pill pill--split text-white background-navy">
                   <div class="pill__content background-salmon">5</div>
                   <div class="pill__content background-olive">2</div>
                   <div class="pill__content background-skyblue">13</div>
                 </div>
+              </a>
             </div>
         </div>
     </nav>

--- a/demo-pages/submissions-staff-agent-view.html
+++ b/demo-pages/submissions-staff-agent-view.html
@@ -25,14 +25,16 @@
 <body class="flex flex--column">
   <header class="site-header site-header--fixed">
     <nav class="site-menu primary inverted">
-        <a href="/demo-pages/crm-example.html" class="site-menu__item">
+        <div class="site-menu__item">
+          <a href="/demo-pages/crm-example.html" class="site-menu__link">
             <span class="card__header-icon pill--circle-medium background-purple text-white mr-2">
                 D
             </span>
             <span class="text--size-lg">
                 Hello Dev
             </span>
-        </a>
+          </a>
+        </div>
         <div class="site-menu__item search">
             <form role="search" aria-label="CRM" _lpchecked="1" class="w-100">
                 <div class="flex flex--align-center">
@@ -42,44 +44,54 @@
                 </div>
             </form>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            Organizations <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+        <div class="site-menu__item has-dropdown">
+            <a href="#" class="site-menu__link">
+                Organizations <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+            </a>
             <div class="dropdown-menu pin-right">
                 <a href="#" class="dropdown-menu__item">
                     dropdown
                 </a>
             </div>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            People <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+        <div class="site-menu__item has-dropdown">
+            <a href="#" class="site-menu__link">
+                People <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+            </a>
             <div class="dropdown-menu pin-right">
                 <a href="#" class="dropdown-menu__item">
                     dropdown
                 </a>
             </div>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            Flow <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+        <div class="site-menu__item has-dropdown">
+            <a href="#" class="site-menu__link">
+                Flow <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+            </a>
             <div class="dropdown-menu pin-right">
                 <a href="#" class="dropdown-menu__item">
                     dropdown
                 </a>
             </div>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            <span class="sr-only">RIMDev</span>
-            <span class="pill--circle-medium background-white text-navy">
-                <i class="pi-rimdev text--size-xl" aria-hidden="true"></i>
-            </span>
-            <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+        <div class="site-menu__item has-dropdown">
+            <a href="#" class="site-menu__link">
+                <span class="sr-only">RIMDev</span>
+                <span class="card__header-icon pill--circle-medium background-white text-navy">
+                    <i class="pi-rimdev" aria-hidden="true"></i>
+                </span> 
+                <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+            </a>
             <div class="dropdown-menu pin-right">
                 <a href="#" class="dropdown-menu__item">
                     dropdown
                 </a>
             </div>
         </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            Recent <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+        <div class="site-menu__item has-dropdown">
+            <a href="#" class="site-menu__link">
+                Recent <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+            </a>
             <div class="dropdown-menu pin-right">
                 <a href="#" class="dropdown-menu__item">
                     dropdown
@@ -89,13 +101,15 @@
     </nav>
     <nav class="site-menu flex--justify-between">
         <div class="site-menu__item has-dropdown">
-          <span class="card__header-icon pill--circle-medium background-salmon text-white mr-2">
-              GG
-          </span>
-          <div class="text--size-lg">
-            Greg Gudis
-          </div>
-          <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+          <a href="#" class="site-menu__link">
+            <span class="card__header-icon pill--circle-medium background-salmon text-white mr-2">
+                GG
+            </span>
+            <div class="text--size-lg">
+              Greg Gudis
+            </div>
+            <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+          </a>
           <div class="dropdown-menu pin-right">
             <a href="#" class="dropdown-menu__item background-white">
               <div class="pill background-olive">
@@ -106,39 +120,57 @@
         </div>
         <div class="flex">
             <div class="site-menu__item">
+              <a href="#" class="site-menu__link">
                 Contracts
+              </a>
             </div>
             <div class="site-menu__item active">
+              <a href="#" class="site-menu__link">
                 Submissions
+              </a>
             </div>
             <div class="site-menu__item">
+              <a href="#" class="site-menu__link">
                 Hierarchy
+              </a>
             </div>
             <div class="site-menu__item">
+              <a href="#" class="site-menu__link">
                 Memberships
+              </a>
             </div>
             <div class="site-menu__item">
+              <a href="#" class="site-menu__link">
                 Licenses
+              </a>
             </div>
             <div class="site-menu__item">
+              <a href="#" class="site-menu__link">
                 Reports
+              </a>
             </div>
-            <div class="site-menu__item">
+            <div class="site-menu__item pui-drawer__open" data-drawer="touches">
+              <a href="#" class="site-menu__link">
                 <i class="pi-phone"></i>
+              </a>
             </div>
             <div class="site-menu__item">
+              <a href="#" class="site-menu__link">
                 <i class="pi-file-cabinet"></i>
                 <div class="ml-1 pill pill--circle text-navy">
                   33
                 </div>
+              </a>
             </div>
             <div class="site-menu__item">
+              <a href="#" class="site-menu__link">
                 <i class="pi-gavel"></i>
                 <div class="pill pill--split text-white background-navy">
                   <div class="pill__content background-salmon">5</div>
                   <div class="pill__content background-olive">2</div>
                   <div class="pill__content background-skyblue">13</div>
                 </div>
+              </a>
             </div>
         </div>
     </nav>

--- a/demo-pages/submissions-staff-flow-view.html
+++ b/demo-pages/submissions-staff-flow-view.html
@@ -12,69 +12,81 @@
 </head>
 <body class="flex flex--column">
   <header class="site-header site-header--fixed">
-    <nav class="site-menu primary inverted">
-        <a href="/demo-pages/crm-example.html" class="site-menu__item">
-            <span class="card__header-icon pill--circle-medium background-purple text-white mr-2">
-                D
-            </span>
-            <span class="text--size-lg">
-                Hello Dev
-            </span>
-        </a>
-        <div class="site-menu__item search">
-            <form role="search" aria-label="CRM" _lpchecked="1" class="w-100">
-                <div class="flex flex--align-center">
-                    <label for="search-input" class="sr-only">Search</label>
-                    <input type="text" id="search-input" placeholder="Type to search..." class="placeholder--light text-white">
-                    <i aria-hidden="true" class="pi-search"></i>
-                </div>
-            </form>
-        </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            Organizations <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
-            <div class="dropdown-menu pin-right">
-                <a href="#" class="dropdown-menu__item">
-                    dropdown
-                </a>
-            </div>
-        </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            People <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
-            <div class="dropdown-menu pin-right">
-                <a href="#" class="dropdown-menu__item">
-                    dropdown
-                </a>
-            </div>
-        </div>
-        <div class="site-menu__item has-dropdown active" tabindex="0">
-            Flow <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
-            <div class="dropdown-menu pin-right">
-                <a href="#" class="dropdown-menu__item">
-                    dropdown
-                </a>
-            </div>
-        </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            <span class="sr-only">RIMDev</span>
-            <span class="pill--circle-medium background-white text-navy">
-                <i class="pi-rimdev text--size-xl" aria-hidden="true"></i>
-            </span>
-            <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
-            <div class="dropdown-menu pin-right">
-                <a href="#" class="dropdown-menu__item">
-                    dropdown
-                </a>
-            </div>
-        </div>
-        <div class="site-menu__item has-dropdown" tabindex="0">
-            Recent <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
-            <div class="dropdown-menu pin-right">
-                <a href="#" class="dropdown-menu__item">
-                    dropdown
-                </a>
-            </div>
-        </div>
-    </nav>
+      <nav class="site-menu primary inverted">
+          <div class="site-menu__item">
+            <a href="/demo-pages/crm-example.html" class="site-menu__link">
+              <span class="card__header-icon pill--circle-medium background-purple text-white mr-2">
+                  D
+              </span>
+              <span class="text--size-lg">
+                  Hello Dev
+              </span>
+            </a>
+          </div>
+          <div class="site-menu__item search">
+              <form role="search" aria-label="CRM" _lpchecked="1" class="w-100">
+                  <div class="flex flex--align-center">
+                      <label for="search-input" class="sr-only">Search</label>
+                      <input type="text" id="search-input" placeholder="Type to search..." class="placeholder--light text-white">
+                      <i aria-hidden="true" class="pi-search"></i>
+                  </div>
+              </form>
+          </div>
+          <div class="site-menu__item has-dropdown">
+              <a href="#" class="site-menu__link">
+                  Organizations <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+              </a>
+              <div class="dropdown-menu pin-right">
+                  <a href="#" class="dropdown-menu__item">
+                      dropdown
+                  </a>
+              </div>
+          </div>
+          <div class="site-menu__item has-dropdown">
+              <a href="#" class="site-menu__link">
+                  People <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+              </a>
+              <div class="dropdown-menu pin-right">
+                  <a href="#" class="dropdown-menu__item">
+                      dropdown
+                  </a>
+              </div>
+          </div>
+          <div class="site-menu__item has-dropdown">
+              <a href="#" class="site-menu__link">
+                  Flow <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+              </a>
+              <div class="dropdown-menu pin-right">
+                  <a href="#" class="dropdown-menu__item">
+                      dropdown
+                  </a>
+              </div>
+          </div>
+          <div class="site-menu__item has-dropdown">
+              <a href="#" class="site-menu__link">
+                  <span class="sr-only">RIMDev</span>
+                  <span class="card__header-icon pill--circle-medium background-white text-navy">
+                      <i class="pi-rimdev" aria-hidden="true"></i>
+                  </span> 
+                  <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+              </a>
+              <div class="dropdown-menu pin-right">
+                  <a href="#" class="dropdown-menu__item">
+                      dropdown
+                  </a>
+              </div>
+          </div>
+          <div class="site-menu__item has-dropdown">
+              <a href="#" class="site-menu__link">
+                  Recent <i class="ml-1 pi-angle-down" aria-hidden="true"></i>
+              </a>
+              <div class="dropdown-menu pin-right">
+                  <a href="#" class="dropdown-menu__item">
+                      dropdown
+                  </a>
+              </div>
+          </div>
+      </nav>
   </header>
   <main class="header-fixed background-light-mid flex--grow py-4 px-5">
     <div class="block-container blocks px-3 mb-4">

--- a/src/assets/stylesheets/sass/_menus.scss
+++ b/src/assets/stylesheets/sass/_menus.scss
@@ -127,7 +127,8 @@
         }
       }
 
-      &.dropdown-active {
+      &.dropdown-active,
+      &.active {
         background-color: color.adjust(config.$primary-menu-color, $lightness: math.percentage(-.05));
       }
     }
@@ -150,7 +151,12 @@
 
   .search {
     flex-grow: 1;
+    padding: 0 map.get(variables.$spacers, 3 );
     @extend %flex-center;
+
+    @include mixins.breakpoint(tablet, min) {
+      padding: 0 map.get(variables.$spacers, 4);
+    }
 
 
     input[type=text] {
@@ -265,6 +271,10 @@
         display: block;
       }
     }
+  }
+
+  &.active {
+    background-color: color.adjust(map.get(variables.$greyscale, 'lighter'), $lightness: math.percentage(-.05));
   }
 }
 


### PR DESCRIPTION
With the recent changes to the site-menu a class needed to be added to `<a>` inside `site-menu__item`s to keep the current padding within the site-menu.