### PR TITLE
Fix non-functional `Copy` button on icons page

### DIFF
--- a/templates/html.hbs
+++ b/templates/html.hbs
@@ -8,7 +8,7 @@
       </span>
 
       <span class="flex--center-content">{{ ../classPrefix }}{{ this }}</span>
-      <div class="button mt-2" data-clipboard-text="<i class='{{ ../classPrefix }}{{ this }}'></i>">
+      <div class="button mt-2 tooltip-bottom" data-copy-button data-clipboard-text="<i class='{{ ../classPrefix }}{{ this }}'></i>">
         Copy <i class="pi-clipboard"></i>
       </div>
 
@@ -18,7 +18,7 @@
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js"></script>
 <script>
-const clipboard = new ClipboardJS('.button.icon');
+const clipboard = new ClipboardJS('[data-copy-button]');
 clipboard.on('success', function(e) {
     e.trigger.setAttribute('data-pui-tooltip', 'Copied!');
     e.clearSelection();


### PR DESCRIPTION
![copy-button](https://user-images.githubusercontent.com/7084030/77430760-0e50bd00-6db2-11ea-8594-dffe34625cfc.gif)
