### PR TITLE
Agencies Flow - switched from using block-container to flex on sorting options

### DIFF
--- a/demo-pages/agency/agencies-flow.html
+++ b/demo-pages/agency/agencies-flow.html
@@ -62,8 +62,8 @@
               <div class="tablet-up-8 flex flex--justify-end flex--align-center mb-3">
 
                 <!-- Sorting -->
-                <div class="block-container hide-tablet-down flex--align-center mr-3">
-                  <div class="mr-2">
+                <div class="flex flex--align-center mr-3">
+                  <div class="mr-2 hide-tablet-down">
                     Sales Modified Date
                     <div class="pill pill--split">
                       <a
@@ -78,7 +78,7 @@
                       </a>
                     </div>
                   </div>
-                  <div class="mr-2">
+                  <div class="mr-2 hide-tablet-down">
                     Modified Date
                     <div class="pill pill--split">
                       <a
@@ -94,7 +94,7 @@
                       </a>
                     </div>
                   </div>
-                  <div class="mr-2">
+                  <div class="mr-2 hide-tablet-down">
                     Created Date
                     <div class="pill pill--split">
                       <a


### PR DESCRIPTION
@tedk13 suggested swapping the usage of `.block-container` to `.flex` instead as there are no `.block` child elements on the sorting options.

- Changed this on parent element which caused the sorting options to still be displayed on mobile
- removed hide-tablet-up from parent and applied to child elements, now working properly

Looks and works the same as before!