### PR TITLE
Trigger the GH Actions build, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ As we continue to improve Platform UI, we hope to create an easy to use framewor
 
 ## Publishing
 
-Platform UI is published privately on a regular basis to [MyGet](https://myget.org/). More infrequent but stable builds are published to [npm](https://www.npmjs.com/) as [@ritterim/platform-ui](https://www.npmjs.com/package/@ritterim/platform-ui).
+Platform UI is published privately on a regular basis to [MyGet](https://myget.org/) and GitHub Packages. Builds are also published to [npm](https://www.npmjs.com/) as [@ritterim/platform-ui](https://www.npmjs.com/package/@ritterim/platform-ui).
+
+The patch version value will be bumped on every merge to the trunk branch.
 
 ## Styleguide
 


### PR DESCRIPTION
I'm not exactly sure what is triggering AppVeyor -- I've deleted the webhook and also deleted the project out of AppVeyor.  (UPDATE: That seems to have fixed it.)

The required rules are also in place

<img width="828" alt="image" src="https://github.com/ritterim/platform-ui/assets/4880437/f6c352d7-9f90-4ccd-b8b2-15d8cd33a229">
