### PR TITLE
Upgrade to v1.4.0 of build workflows/actions

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -16,7 +16,7 @@ on:
 jobs:
 
   pr-build:
-    uses: ritterim/public-github-actions/.github/workflows/npm-packages-pr-build.yml@v1.3.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-packages-pr-build.yml@v1.4.0
     #uses: ./.github/workflows/npm-packages-pr-build.yml
     with:
       always_increment_patch_version: true

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -11,7 +11,7 @@ on:
   # By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened.
   # We want to run on 'closed' to trigger, but we also have to check if it was merged.
   # That check is: if: github.event.pull_request.merged == true
-  pull_request:
+  pull_request_target:
     types: [ closed ]
     branches:
       - master
@@ -19,7 +19,7 @@ on:
 jobs:
 
   npm-packages-pr-create-tag:
-    uses: ritterim/public-github-actions/.github/workflows/npm-packages-pr-create-tag.yml@v1.3.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-packages-pr-create-tag.yml@v1.4.0
     #uses: ./.github/workflows/npm-packages-pr-create-tag.yml
     if: github.event.pull_request.merged == true
     secrets:

--- a/.github/workflows/version-tag-build-master.yml
+++ b/.github/workflows/version-tag-build-master.yml
@@ -15,7 +15,7 @@ on:
 jobs:
 
   version-tag-build:
-    uses: ritterim/public-github-actions/.github/workflows/npm-packages-release-on-tag.yml@v1.3.0
+    uses: ritterim/public-github-actions/.github/workflows/npm-packages-release-on-tag.yml@v1.4.0
     #uses: ./.github/workflows/npm-packages-release-on-tag.yml
     secrets:
       myget_api_key: ${{ secrets.MYGET_DEPLOY_API_KEY_SECRET }}


### PR DESCRIPTION
- v1.4.0 of the ritterim/public-github-acitons fixes a vulnerability, plus has some bug fixes for later parts of the pipeline.

- Switch to using 'pull_request_target'.  We've hopefully structured our workflows in a way that avoids exploits of this GitHub Actions trigger.