### PR TITLE
bugfix: updates specificty for `&:last-child > td`

### DIFF
--- a/src/sass/_tables.scss
+++ b/src/sass/_tables.scss
@@ -64,7 +64,7 @@
     }
 
     &:last-child {
-      td {
+      > td {
         border-color: transparent;
       }
     }


### PR DESCRIPTION
Issue:
https://github.com/ritterim/platform/issues/10816

Updates:
- Adds direct child specificity to `&:last-child > td`